### PR TITLE
초대 메일 API 변경

### DIFF
--- a/config/param-validation.js
+++ b/config/param-validation.js
@@ -34,8 +34,8 @@ module.exports = {
   },
   // POST /api/mails/invitation/users/:userId
   sendInvitation: {
-    params: {
-      userId: Joi.string().required()
+    body: {
+      invitee: Joi.string().hex().required()
     }
   }
 };

--- a/routes/v1/mail.route.js
+++ b/routes/v1/mail.route.js
@@ -7,23 +7,11 @@ const paramValidation = require('../../config/param-validation'),
 
 const router = express.Router(); // eslint-disable-line new-cap
 
-router.route('/invitation/users/:userId')
-  .post(function(req, res, next){
-      req.receiver = req.user;
-      next();
-  }, function(req, res, next) {
-    userCtrl.load(req, res, next, req.decoded._id);
-  }, mailCtrl.sendInvitation);
-
-// TODO
 router.route('/invitation')
-  .post(
-    // validate(paramValidation.sendInvitation), 
-  function(req, res, next){
-    userCtrl.load(req, res, next, req.body.invitee);
+  .post(validate(paramValidation.sendInvitation), 
+  (req, res, next) => userCtrl.load(req, res, next, req.body.invitee),
+  (req, res, next) => {
     req.receiver = req.user;
-    next();
-  }, function(req, res, next) {
     userCtrl.load(req, res, next, req.decoded._id);
   }, mailCtrl.sendInvitation);
 


### PR DESCRIPTION
 - 메일 API URL을 보았을 때, :userId가 초대 받는 사람인지 판별하기가 어려워 변경
 - AS-IS
   - POST /v1/groups/:groupId/mails/invitation/users/:userId
- TO-BE
   - POST /v1/groups/:groupId/mails/invitation

- 관련 이슈
  - https://github.com/JAVACAFE-STUDY/chainity-api/issues/15
- API 정의서
 
  - https://docs.google.com/document/d/188ltFzEhpHYZ0fJUuO20wMbCeFm5OTqEyItZmXEgEEQ/edit#heading=h.rb8gblnu9kdo