### PR TITLE
블록체인 원장 에러 핸들링 변경

### DIFF
--- a/controllers/reward.controller.js
+++ b/controllers/reward.controller.js
@@ -93,7 +93,7 @@ function create(req, res, next) {
         savedReward.save();
       }).on('error', console.error);
     })
-    .catch(e => next(e));
+    .catch(e => console.error(e));
 }
 
 module.exports = { list, create };


### PR DESCRIPTION
블록체인 원장 기록 실패시
- AS-IS
이미 Response를 리턴한 API 요청 응답값에 접근하려하여 `can't set header...` 에러 발생으로 기존 Error stack trace 확인 불가
- TO-BE
에러 로깅으로 변경